### PR TITLE
Ruff: Make filesystem config files first preference

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
                 },
                 "rewrap.wrappingColumn": 100
             },
+            "ruff.configurationPreference": "filesystemFirst",
             "ruff.lineLength": 100,
             "ruff.lint.select": [
                 "ALL"


### PR DESCRIPTION
This pull request makes a minor update to the `package.json` configuration, specifically adjusting a setting for the Ruff linter to prefer configuration files found in the filesystem like the pyproject.toml. This change helps ensure that Ruff uses the most relevant configuration when linting code.